### PR TITLE
Create clone_private_repo.yml

### DIFF
--- a/.github/workflows/clone_private_repo.yml
+++ b/.github/workflows/clone_private_repo.yml
@@ -1,0 +1,29 @@
+name: "Build environment"
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_env:
+    name: "Build"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: checkout test
+        uses: actions/checkout@v3
+        with:
+          repository: JoranAngevaare/test_actions
+          ssh-key: ${{ secrets.test_actions_test_token }}
+          path: test
+          ref: master
+          fetch-depth: 0
+
+      - name: List files
+        run: ls test

--- a/.github/workflows/clone_private_repo.yml
+++ b/.github/workflows/clone_private_repo.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: JoranAngevaare/test_actions
-          ssh-key: ${{ secrets.test_actions_test_token }}
+          token: ${{ secrets.TEST_ACTIONS_TEST_TOKEN }}
           path: test
           ref: master
           fetch-depth: 0

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,38 +1,38 @@
-# Test package every time
+# # Test package every time
 
-name: Pytest
+# name: Pytest
 
-# Controls when the action will run.
+# # Controls when the action will run.
 
-# Trigger this code when a new release is published
-on:
-  workflow_dispatch:
-  release:
-    types: [created]
-  pull_request:
-  push:
-    branches:
-      - master
+# # Trigger this code when a new release is published
+# on:
+#   workflow_dispatch:
+#   release:
+#     types: [created]
+#   pull_request:
+#   push:
+#     branches:
+#       - master
 
-jobs:
-  test_package:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.8"]
-    steps:
-      - name: Setup python
-        uses: actions/setup-python@v2 # https://github.com/marketplace/actions/setup-miniconda
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Checkout repo
-        uses: actions/checkout@v2.3.5
-      - name: Install python dependencies
-        uses: py-actions/py-dependency-install@v3
-      - name: Install dependencies
-        run: |
-          python setup.py test
-      - name: goodbye
-        run: echo goodbye
+# jobs:
+#   test_package:
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os: ["ubuntu-latest"]
+#         python-version: ["3.8"]
+#     steps:
+#       - name: Setup python
+#         uses: actions/setup-python@v2 # https://github.com/marketplace/actions/setup-miniconda
+#         with:
+#           python-version: ${{ matrix.python-version }}
+#       - name: Checkout repo
+#         uses: actions/checkout@v2.3.5
+#       - name: Install python dependencies
+#         uses: py-actions/py-dependency-install@v3
+#       - name: Install dependencies
+#         run: |
+#           python setup.py test
+#       - name: goodbye
+#         run: echo goodbye


### PR DESCRIPTION
Clone private repo

## Summary by Sourcery

Introduce a new GitHub Actions workflow to clone a private repository for build environment validation

CI:
- Add clone_private_repo.yml workflow triggered on manual dispatch, release creation, pull requests, and pushes to master
- Define a build job that checks out the main repo and a private test repository via SSH key, then lists its files